### PR TITLE
README/minor: fix Cluster API link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elemental CAPI Infrastructure Provider
 
-This infrastructure provider brings the Elemental stack into the [Kubernete's Cluster API](cluster-api.sigs.k8s.io/).  
+This infrastructure provider brings the Elemental stack into the [Kubernetes Cluster API](https://cluster-api.sigs.k8s.io/).
 
 Elemental is a software stack enabling centralized, full cloud-native OS management with Kubernetes.  
 For more information about the current features, please read the [official documentation](https://elemental.docs.rancher.com/).  


### PR DESCRIPTION
Without the heading "https://" the link is rendered as a local resource link:
https://github.com/rancher-sandbox/cluster-api-provider-elemental/blob/main/cluster-api.sigs.k8s.io