### PR TITLE
Improve kubeadm image

### DIFF
--- a/Dockerfile.os
+++ b/Dockerfile.os
@@ -1,4 +1,6 @@
-FROM opensuse/leap:15.5 as AGENT
+ARG ELEMENTAL_TOOLKIT=ghcr.io/rancher/elemental-toolkit/elemental-cli:v1.1.0
+
+FROM registry.opensuse.org/opensuse/leap:15.5 as AGENT
 
 # Install Go 1.22
 RUN zypper install -y wget tar gzip gcc
@@ -42,10 +44,10 @@ RUN CGO_ENABLED=1 go build \
     -buildmode=plugin \
     -o dummy.so internal/agent/plugin/dummy/dummy.go
 
-FROM  ghcr.io/rancher/elemental-toolkit/elemental-cli:v1.1.0 as TOOLKIT
+FROM  ${ELEMENTAL_TOOLKIT} as TOOLKIT
 
 # OS base image of our choice
-FROM opensuse/leap:15.5 as OS
+FROM registry.opensuse.org/opensuse/leap:15.5 as OS
 
 ARG AGENT_CONFIG_FILE=iso/config/example-config.yaml
 
@@ -86,7 +88,10 @@ RUN ARCH=$(uname -m); \
       curl \
       sed \
       iptables \
-      iproute2 
+      iproute2 \
+      btrfsprogs \
+      btrfsmaintenance \
+      snapper
 
 # Add the elemental cli
 COPY --from=TOOLKIT /usr/bin/elemental /usr/bin/elemental

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ build-iso: build-os
 	$(CONTAINER_TOOL) run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ./iso:/iso \
 		--entrypoint /usr/bin/elemental docker.io/library/elemental-os:dev \
 		--config-dir . --debug build-iso -n elemental-dev \
-		-o /iso dir:/
+		--local -o /iso docker.io/library/elemental-os:dev
 
 .PHONY: build-os-kubeadm
 build-os-kubeadm: 
@@ -275,7 +275,6 @@ ifeq ($(AGENT_CONFIG_FILE),"iso/config/example-config.yaml")
 	@echo "No AGENT_CONFIG_FILE set, using the default one at ${AGENT_CONFIG_FILE}"
 endif
 	$(CONTAINER_TOOL) build \
-		--no-cache \
 		--build-arg "TAG=${GIT_TAG}" \
 		--build-arg "COMMIT=${GIT_COMMIT}" \
 		--build-arg "COMMITDATE=${GIT_COMMIT_DATE}" \
@@ -287,7 +286,7 @@ build-iso-kubeadm: build-os-kubeadm
 	$(CONTAINER_TOOL) run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ./iso:/iso \
 		--entrypoint /usr/bin/elemental docker.io/library/elemental-os:dev-kubeadm \
 		--config-dir . --debug build-iso -n elemental-dev-kubeadm \
-		-o /iso dir:/
+		--local -o /iso docker.io/library/elemental-os:dev-kubeadm
 
 .PHONY: update-test-capi-crds
 update-test-capi-crds: 

--- a/Makefile
+++ b/Makefile
@@ -250,8 +250,8 @@ lint: ## See: https://golangci-lint.run/usage/linters/
 
 AGENT_CONFIG_FILE?="iso/config/example-config.yaml"
 
-.PHONY: build-iso
-build-iso: 
+.PHONY: build-os
+build-os: 
 ifeq ($(AGENT_CONFIG_FILE),"iso/config/example-config.yaml")
 	@echo "No AGENT_CONFIG_FILE set, using the default one at ${AGENT_CONFIG_FILE}"
 endif
@@ -260,25 +260,34 @@ endif
 		--build-arg "COMMIT=${GIT_COMMIT}" \
 		--build-arg "COMMITDATE=${GIT_COMMIT_DATE}" \
 		--build-arg "AGENT_CONFIG_FILE=${AGENT_CONFIG_FILE}" \
-		-t elemental-iso:latest -f Dockerfile.iso .
+		-t elemental-os:dev -f Dockerfile.os .
+
+.PHONY: build-iso
+build-iso: build-os
 	$(CONTAINER_TOOL) run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ./iso:/iso \
-		--entrypoint /usr/bin/elemental docker.io/library/elemental-iso:latest --config-dir . --debug build-iso --bootloader-in-rootfs -n elemental-dev \
-		--local --squash-no-compression -o /iso docker.io/library/elemental-iso:latest
+		--entrypoint /usr/bin/elemental docker.io/library/elemental-os:dev \
+		--config-dir . --debug build-iso -n elemental-dev \
+		-o /iso dir:/
+
+.PHONY: build-os-kubeadm
+build-os-kubeadm: 
+ifeq ($(AGENT_CONFIG_FILE),"iso/config/example-config.yaml")
+	@echo "No AGENT_CONFIG_FILE set, using the default one at ${AGENT_CONFIG_FILE}"
+endif
+	$(CONTAINER_TOOL) build \
+		--no-cache \
+		--build-arg "TAG=${GIT_TAG}" \
+		--build-arg "COMMIT=${GIT_COMMIT}" \
+		--build-arg "COMMITDATE=${GIT_COMMIT_DATE}" \
+		--build-arg "AGENT_CONFIG_FILE=${AGENT_CONFIG_FILE}" \
+		-t elemental-os:dev-kubeadm -f Dockerfile.kubeadm.os .
 
 .PHONY: build-iso-kubeadm
-build-iso-kubeadm: 
-ifeq ($(AGENT_CONFIG_FILE),"iso/config/example-config.yaml")
-	@echo "No AGENT_CONFIG_FILE set, using the default one at ${AGENT_CONFIG_FILE}"
-endif
-	$(CONTAINER_TOOL) build \
-		--build-arg "TAG=${GIT_TAG}" \
-		--build-arg "COMMIT=${GIT_COMMIT}" \
-		--build-arg "COMMITDATE=${GIT_COMMIT_DATE}" \
-		--build-arg "AGENT_CONFIG_FILE=${AGENT_CONFIG_FILE}" \
-		-t elemental-iso:latest -f Dockerfile.kubeadm.iso .
+build-iso-kubeadm: build-os-kubeadm
 	$(CONTAINER_TOOL) run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ./iso:/iso \
-		--entrypoint /usr/bin/elemental docker.io/library/elemental-iso:latest --config-dir . --debug build-iso --bootloader-in-rootfs -n elemental-dev \
-		--local --squash-no-compression -o /iso docker.io/library/elemental-iso:latest
+		--entrypoint /usr/bin/elemental docker.io/library/elemental-os:dev-kubeadm \
+		--config-dir . --debug build-iso -n elemental-dev-kubeadm \
+		-o /iso dir:/
 
 .PHONY: update-test-capi-crds
 update-test-capi-crds: 

--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -31,6 +31,7 @@ stages:
           /etc/cni
           /etc/conntrackd
           /etc/containerd
+          /usr/libexec
           /home
           /opt
           /root

--- a/framework/files/system/oem/01_elemental-rootfs.yaml
+++ b/framework/files/system/oem/01_elemental-rootfs.yaml
@@ -27,24 +27,15 @@ stages:
           /etc/kubernetes
           /etc/rancher
           /etc/ssh
-          /etc/iscsi 
+          /etc/iscsi
           /etc/cni
           /etc/conntrackd
+          /etc/containerd
           /home
           /opt
           /root
-          /usr/libexec
           /var/log
-          /var/lib/elemental
-          /var/lib/rancher
-          /var/lib/kubelet
-          /var/lib/NetworkManager
-          /var/lib/longhorn
-          /var/lib/cni
-          /var/lib/calico
-          /var/lib/containers
-          /var/lib/crio
-          /var/lib/etcd
+          /var/lib
         PERSISTENT_STATE_BIND: "true"
     - if: '[ -f "/run/cos/recovery_mode" ]'
       # omit the persistent partition on recovery mode

--- a/framework/files/system/oem/99_kubeadm_hack.yaml
+++ b/framework/files/system/oem/99_kubeadm_hack.yaml
@@ -1,0 +1,13 @@
+# TODO: kubeadm binaries needs to be in PATH for the bootstrap to work. 
+#       They should live in /usr/local/sbin, but that requires a newer version of elemental-toolkit.
+#       This is just a dirty workaround.
+name: "Kubeadm /usr/local/sbin hack"
+stages:
+  boot:
+    - if: '[ -d "/opt/kubeadm/bin" ]'
+      name: "Link kubeadm binaries to /usr/local/sbin"
+      commands: 
+        - "ln -s /opt/kubeadm/bin/kubeadm /usr/local/sbin/kubeadm"
+        - "ln -s /opt/kubeadm/bin/kubelet /usr/local/sbin/kubelet"
+        - "ln -s /opt/kubeadm/bin/kubectl /usr/local/sbin/kubectl"
+        - "ln -s /opt/kubeadm/bin/crictl /usr/local/sbin/crictl"

--- a/framework/files/system/oem/99_kubeadm_hack.yaml
+++ b/framework/files/system/oem/99_kubeadm_hack.yaml
@@ -4,7 +4,7 @@
 name: "Kubeadm /usr/local/sbin hack"
 stages:
   boot:
-    - if: '[ -d "/opt/kubeadm/bin" ]'
+    - if: '[ -f /run/cos/active_mode ] && [ -d /opt/kubeadm/bin ]'
       name: "Link kubeadm binaries to /usr/local/sbin"
       commands: 
         - "ln -s /opt/kubeadm/bin/kubeadm /usr/local/sbin/kubeadm"

--- a/framework/files/system/oem/99_kubeadm_hack.yaml
+++ b/framework/files/system/oem/99_kubeadm_hack.yaml
@@ -11,3 +11,8 @@ stages:
         - "ln -s /opt/kubeadm/bin/kubelet /usr/local/sbin/kubelet"
         - "ln -s /opt/kubeadm/bin/kubectl /usr/local/sbin/kubectl"
         - "ln -s /opt/kubeadm/bin/crictl /usr/local/sbin/crictl"
+#   This keeps the kubelet happy, otherwise it will complain it can't access /etc/kubernetes/manifests on worker nodes.
+    - if: '[ -f /run/cos/active_mode ] && [ -d /opt/kubeadm/bin ]'
+      name: "Create Kubernetes manifests dir"
+      commands: 
+        - "mkdir -p /etc/kubernetes/manifests"

--- a/infrastructure-elemental/v0.0.0/cluster-template-kubeadm-clusterclass.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-kubeadm-clusterclass.yaml
@@ -15,7 +15,7 @@ spec:
     serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
   topology:
     class: kubeadm
-    version: ${KUBERNETES_VERSION:="1.28.5"}
+    version: ${KUBERNETES_VERSION:="1.29.3"}
     controlPlane:
       metadata: {}
       replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}

--- a/infrastructure-elemental/v0.0.0/cluster-template-kubeadm.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-kubeadm.yaml
@@ -56,7 +56,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: ElementalMachineTemplate
         name: ${CLUSTER_NAME}-md-0
-      version: ${KUBERNETES_VERSION:=1.28.5}
+      version: ${KUBERNETES_VERSION:=1.29.3}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -67,7 +67,7 @@ metadata:
   namespace: ${NAMESPACE}
 spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
-  version: ${KUBERNETES_VERSION:=1.28.5}
+  version: ${KUBERNETES_VERSION:=1.29.3}
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -105,16 +105,20 @@ spec:
               value: ${VIP_INTERFACE:=eth0}
             - name: vip_cidr
               value: "32"
+            - name: dns_mode
+              value: first
             - name: cp_enable
               value: "true"
             - name: cp_namespace
               value: kube-system
-            - name: vip_ddns
-              value: "false"
             - name: svc_enable
               value: "true"
+            - name: svc_leasename
+              value: plndr-svcs-lock
             - name: vip_leaderelection
               value: "true"
+            - name: vip_leasename
+              value: plndr-cp-lock
             - name: vip_leaseduration
               value: "5"
             - name: vip_renewdeadline
@@ -123,7 +127,9 @@ spec:
               value: "1"
             - name: address
               value: ${CONTROL_PLANE_ENDPOINT_HOST}
-            image: ghcr.io/kube-vip/kube-vip:v0.6.4
+            - name: prometheus_server
+              value: :2112
+            image: ghcr.io/kube-vip/kube-vip:v0.7.2
             imagePullPolicy: Always
             name: kube-vip
             resources: {}
@@ -132,7 +138,6 @@ spec:
                 add:
                 - NET_ADMIN
                 - NET_RAW
-                - SYS_TIME
             volumeMounts:
             - mountPath: /etc/kubernetes/admin.conf
               name: kubeconfig
@@ -143,19 +148,11 @@ spec:
           hostNetwork: true
           volumes:
           - hostPath:
-              path: /etc/kubernetes/admin.conf
+              path: /etc/kubernetes/super-admin.conf
             name: kubeconfig
         status: {}
       owner: root:root
       path: /etc/kubernetes/manifests/kube-vip.yaml
-    initConfiguration:
-      nodeRegistration:
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-    joinConfiguration:
-      nodeRegistration:
-        kubeletExtraArgs:
-          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElementalCluster

--- a/infrastructure-elemental/v0.0.0/cluster-template-kubeadm.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-kubeadm.yaml
@@ -75,15 +75,26 @@ spec:
       name: ${CLUSTER_NAME}-control-plane
       namespace: ${NAMESPACE}
   kubeadmConfigSpec:
+    initConfiguration:
+      apiVersion: kubeadm.k8s.io/v1beta1
+      kind: InitConfiguration
+      localAPIEndpoint: {}
+      nodeRegistration:
+        imagePullPolicy: IfNotPresent
     clusterConfiguration:
       apiServer:
         certSANs:
-        - localhost
-        - 127.0.0.1
-        - 0.0.0.0
+          - localhost
+          - 127.0.0.1
+          - 0.0.0.0
       controllerManager:
         extraArgs:
           enable-hostpath-provisioner: "true"
+      dns: {}
+      etcd: {}
+      networking: {}
+      scheduler: {}
+    format: cloud-config
     files:
     - content: |
         apiVersion: v1

--- a/infrastructure-elemental/v0.0.0/cluster-template-kubeadm.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-kubeadm.yaml
@@ -84,9 +84,9 @@ spec:
     clusterConfiguration:
       apiServer:
         certSANs:
-          - localhost
-          - 127.0.0.1
-          - 0.0.0.0
+        - localhost
+        - 127.0.0.1
+        - 0.0.0.0
       controllerManager:
         extraArgs:
           enable-hostpath-provisioner: "true"

--- a/infrastructure-elemental/v0.0.0/clusterclass-kubeadm.yaml
+++ b/infrastructure-elemental/v0.0.0/clusterclass-kubeadm.yaml
@@ -178,9 +178,9 @@ spec:
         clusterConfiguration:
           apiServer:
             certSANs:
-              - localhost
-              - 127.0.0.1
-              - 0.0.0.0
+            - localhost
+            - 127.0.0.1
+            - 0.0.0.0
           controllerManager:
             extraArgs:
               enable-hostpath-provisioner: "true"

--- a/infrastructure-elemental/v0.0.0/clusterclass-kubeadm.yaml
+++ b/infrastructure-elemental/v0.0.0/clusterclass-kubeadm.yaml
@@ -169,15 +169,26 @@ spec:
   template:
     spec:
       kubeadmConfigSpec:
+        initConfiguration:
+          apiVersion: kubeadm.k8s.io/v1beta1
+          kind: InitConfiguration
+          localAPIEndpoint: {}
+          nodeRegistration:
+            imagePullPolicy: IfNotPresent
         clusterConfiguration:
           apiServer:
             certSANs:
-            - localhost
-            - 127.0.0.1
-            - 0.0.0.0
+              - localhost
+              - 127.0.0.1
+              - 0.0.0.0
           controllerManager:
             extraArgs:
               enable-hostpath-provisioner: "true"
+          dns: {}
+          etcd: {}
+          networking: {}
+          scheduler: {}
+        format: cloud-config
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElementalMachineTemplate

--- a/infrastructure-elemental/v0.0.0/clusterclass-kubeadm.yaml
+++ b/infrastructure-elemental/v0.0.0/clusterclass-kubeadm.yaml
@@ -101,16 +101,20 @@ spec:
                             value: {{ .vipInterface }}
                           - name: vip_cidr
                             value: "32"
+                          - name: dns_mode
+                            value: first
                           - name: cp_enable
                             value: "true"
                           - name: cp_namespace
                             value: kube-system
-                          - name: vip_ddns
-                            value: "false"
                           - name: svc_enable
                             value: "true"
+                          - name: svc_leasename
+                            value: plndr-svcs-lock
                           - name: vip_leaderelection
                             value: "true"
+                          - name: vip_leasename
+                            value: plndr-cp-lock
                           - name: vip_leaseduration
                             value: "5"
                           - name: vip_renewdeadline
@@ -119,7 +123,9 @@ spec:
                             value: "1"
                           - name: address
                             value: {{ .controlPlaneEndpointHost }}
-                          image: ghcr.io/kube-vip/kube-vip:v0.6.4
+                          - name: prometheus_server
+                            value: :2112
+                          image: ghcr.io/kube-vip/kube-vip:v0.7.2
                           imagePullPolicy: Always
                           name: kube-vip
                           resources: {}
@@ -128,7 +134,6 @@ spec:
                               add:
                               - NET_ADMIN
                               - NET_RAW
-                              - SYS_TIME
                           volumeMounts:
                           - mountPath: /etc/kubernetes/admin.conf
                             name: kubeconfig
@@ -139,7 +144,7 @@ spec:
                         hostNetwork: true
                         volumes:
                         - hostPath:
-                            path: /etc/kubernetes/admin.conf
+                            path: /etc/kubernetes/super-admin.conf
                           name: kubeconfig
                       status: {}
                     owner: root:root
@@ -173,14 +178,6 @@ spec:
           controllerManager:
             extraArgs:
               enable-hostpath-provisioner: "true"
-        initConfiguration:
-          nodeRegistration:
-            kubeletExtraArgs:
-              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
-        joinConfiguration:
-          nodeRegistration:
-            kubeletExtraArgs:
-              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElementalMachineTemplate

--- a/iso/crio-overlay-storage.conf
+++ b/iso/crio-overlay-storage.conf
@@ -1,3 +1,0 @@
-[crio]
-  storage_driver = "overlay"
-  storage_option = ["overlay.mount_program=/usr/bin/fuse-overlayfs"]

--- a/test/scripts/install_kubeadm_stack.sh
+++ b/test/scripts/install_kubeadm_stack.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
 # See: https://github.com/go4clouds/cloud-infra/blob/main/libvirt/provision-k8s-node.sh

--- a/test/scripts/install_kubeadm_stack.sh
+++ b/test/scripts/install_kubeadm_stack.sh
@@ -1,0 +1,433 @@
+#!/bin/sh
+
+# See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
+# See: https://github.com/go4clouds/cloud-infra/blob/main/libvirt/provision-k8s-node.sh
+
+set -e
+
+ARCH=$(uname -m)
+if [[ $ARCH == "aarch64" ]]; then ARCH="arm64"; fi;
+if [[ $ARCH == "x86_64" ]]; then ARCH="amd64"; fi;
+
+DOWNLOAD_DIR="/opt/kubeadm/bin"
+mkdir -p "$DOWNLOAD_DIR"
+
+## CNI Plugins
+CNI_PLUGINS_VERSION="v1.4.1"
+DEST="/opt/cni/bin"
+mkdir -p "$DEST"
+curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-${ARCH}-${CNI_PLUGINS_VERSION}.tgz" | tar -C "$DEST" -xz
+
+## crictl
+CRICTL_VERSION="v1.29.0"
+curl -L "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-${ARCH}.tar.gz" | tar -C $DOWNLOAD_DIR -xz
+
+## kubeadm/kubelet
+## See: https://www.downloadkubernetes.com/
+RELEASE="v1.29.3"
+ARCH="amd64"
+cd $DOWNLOAD_DIR
+curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH}/{kubeadm,kubelet}
+chmod +x {kubeadm,kubelet}
+
+RELEASE_VERSION="v0.16.5"
+mkdir -p /usr/lib/systemd/system/kubelet.service.d
+
+#curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubelet/kubelet.service" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service
+cat >> /usr/lib/systemd/system/kubelet.service << EOF
+[Unit]
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/
+Wants=network-online.target
+After=network-online.target
+# Do not start in Elemental Recovery or Live mode
+ConditionPathExists=!/run/elemental/live_mode
+ConditionPathExists=!/run/elemental/recovery_mode
+
+[Service]
+ExecStart=/opt/kubeadm/bin/kubelet
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+curl -sSL "https://raw.githubusercontent.com/kubernetes/release/${RELEASE_VERSION}/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+
+## kubectl
+curl -LO https://dl.k8s.io/release/${RELEASE}/bin/linux/amd64/kubectl
+chmod +x kubectl
+
+## containerd
+CONTAINERD_VERSION="1.7.14"
+curl -L "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/containerd-${CONTAINERD_VERSION}-linux-${ARCH}.tar.gz" | tar  --strip-components=1 -C "$DOWNLOAD_DIR" -xz
+
+#curl -sSL "https://raw.githubusercontent.com/containerd/containerd/main/containerd.service" | sed "s:/usr/bin:${DOWNLOAD_DIR}:g" | tee /usr/lib/systemd/system/containerd.service
+cat >> /usr/lib/systemd/system/containerd.service << EOF
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
+# Do not start in Elemental Recovery or Live mode
+ConditionPathExists=!/run/elemental/live_mode
+ConditionPathExists=!/run/elemental/recovery_mode
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/opt/kubeadm/bin/containerd
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+## containerd config
+## Generate a default config with 'containerd config default'
+
+mkdir -p /etc/containerd
+cat >> /etc/containerd/config.toml << EOF
+disabled_plugins = []
+imports = []
+oom_score = 0
+plugin_dir = ""
+required_plugins = []
+root = "/var/lib/containerd"
+state = "/run/containerd"
+temp = ""
+version = 2
+
+[cgroup]
+  path = ""
+
+[debug]
+  address = ""
+  format = ""
+  gid = 0
+  level = "debug"
+  uid = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+  tcp_address = ""
+  tcp_tls_ca = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 0
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[plugins]
+
+  [plugins."io.containerd.gc.v1.scheduler"]
+    deletion_threshold = 0
+    mutation_threshold = 100
+    pause_threshold = 0.02
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    cdi_spec_dirs = ["/etc/cdi", "/var/run/cdi"]
+    device_ownership_from_security_context = false
+    disable_apparmor = false
+    disable_cgroup = false
+    disable_hugetlb_controller = true
+    disable_proc_mount = false
+    disable_tcp_service = true
+    drain_exec_sync_io_timeout = "0s"
+    enable_cdi = false
+    enable_selinux = false
+    enable_tls_streaming = false
+    enable_unprivileged_icmp = false
+    enable_unprivileged_ports = false
+    ignore_deprecation_warnings = []
+    ignore_image_defined_volumes = false
+    image_pull_progress_timeout = "5m0s"
+    image_pull_with_sync_fs = false
+    max_concurrent_downloads = 3
+    max_container_log_line_size = 16384
+    netns_mounts_under_state_dir = false
+    restrict_oom_score_adj = false
+    sandbox_image = "registry.k8s.io/pause:3.8"
+    selinux_category_range = 1024
+    stats_collect_period = 10
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    systemd_cgroup = false
+    tolerate_missing_hugetlb_controller = true
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+      ip_pref = ""
+      max_conf_num = 1
+      setup_serially = false
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runc"
+      disable_snapshot_annotations = true
+      discard_unpacked_layers = false
+      ignore_blockio_not_enabled_errors = false
+      ignore_rdt_not_enabled_errors = false
+      no_pivot = false
+      snapshotter = "overlayfs"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        privileged_without_host_devices_all_devices_allowed = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+        sandbox_mode = ""
+        snapshotter = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          privileged_without_host_devices_all_devices_allowed = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+          sandbox_mode = "podsandbox"
+          snapshotter = ""
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = ""
+            CriuImagePath = ""
+            CriuPath = ""
+            CriuWorkPath = ""
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            NoPivotRoot = false
+            Root = ""
+            ShimCgroup = ""
+            SystemdCgroup = true
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        privileged_without_host_devices_all_devices_allowed = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+        sandbox_mode = ""
+        snapshotter = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+    [plugins."io.containerd.grpc.v1.cri".image_decryption]
+      key_model = "node"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+
+  [plugins."io.containerd.internal.v1.tracing"]
+    sampling_ratio = 1.0
+    service_name = "containerd"
+
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+
+  [plugins."io.containerd.nri.v1.nri"]
+    disable = true
+    disable_connections = false
+    plugin_config_path = "/etc/nri/conf.d"
+    plugin_path = "/opt/nri/plugins"
+    plugin_registration_timeout = "5s"
+    plugin_request_timeout = "2s"
+    socket_path = "/var/run/nri/nri.sock"
+
+  [plugins."io.containerd.runtime.v1.linux"]
+    no_shim = false
+    runtime = "runc"
+    runtime_root = ""
+    shim = "containerd-shim"
+    shim_debug = false
+
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["linux/amd64"]
+    sched_core = false
+
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+
+  [plugins."io.containerd.service.v1.tasks-service"]
+    blockio_config_file = ""
+    rdt_config_file = ""
+
+  [plugins."io.containerd.snapshotter.v1.aufs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.blockfile"]
+    fs_type = ""
+    mount_options = []
+    root_path = ""
+    scratch_file = ""
+
+  [plugins."io.containerd.snapshotter.v1.btrfs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
+    async_remove = false
+    base_image_size = ""
+    discard_blocks = false
+    fs_options = ""
+    fs_type = ""
+    pool_name = ""
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.native"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    mount_options = []
+    root_path = ""
+    sync_remove = false
+    upperdir_label = false
+
+  [plugins."io.containerd.snapshotter.v1.zfs"]
+    root_path = ""
+
+  [plugins."io.containerd.tracing.processor.v1.otlp"]
+    endpoint = ""
+    insecure = false
+    protocol = ""
+
+  [plugins."io.containerd.transfer.v1.local"]
+    config_path = ""
+    max_concurrent_downloads = 3
+    max_concurrent_uploaded_layers = 3
+
+    [[plugins."io.containerd.transfer.v1.local".unpack_config]]
+      differ = ""
+      platform = "linux/amd64"
+      snapshotter = "overlayfs"
+
+[proxy_plugins]
+
+[stream_processors]
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar"
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+[timeouts]
+  "io.containerd.timeout.bolt.open" = "0s"
+  "io.containerd.timeout.metrics.shimstats" = "2s"
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[ttrpc]
+  address = ""
+  gid = 0
+  uid = 0
+
+EOF
+
+## Preflight checks
+# See: https://github.com/go4clouds/cloud-infra/blob/main/libvirt/provision-os-node.sh
+
+# Load br_netfilter
+cat >> /etc/modules-load.d/99-k8s.conf << EOF
+overlay
+br_netfilter
+EOF
+
+# Network-related sysctls
+cat >> /etc/sysctl.d/99-k8s.conf << EOF
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
+net.ipv4.conf.all.forwarding = 1
+EOF

--- a/test/scripts/install_kubeadm_stack.sh
+++ b/test/scripts/install_kubeadm_stack.sh
@@ -3,6 +3,9 @@
 # See: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
 # See: https://github.com/go4clouds/cloud-infra/blob/main/libvirt/provision-k8s-node.sh
 
+# Mind the /usr/local/sbin hack in ../../framework/files/system/oem/99_kubeadm_hack.yaml
+# Additional binaries to pass preflight (if any) need to be in PATH
+
 set -e
 
 ARCH=$(uname -m)


### PR DESCRIPTION
A second take on fixing the kubeadm bootstrapping. 
This time I'm not going to bump the elemental-toolkit, to minimize the PR scope. All binaries can be put into `/opt` for the time being.