### PR TITLE
Display association status

### DIFF
--- a/api/v1beta1/elementalhost_types.go
+++ b/api/v1beta1/elementalhost_types.go
@@ -56,6 +56,11 @@ func (h *ElementalHost) SetConditions(conditions clusterv1.Conditions) {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
+//+kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.labels['elementalhost\\.infrastructure\\.cluster\\.x-k8s\\.io/machine-name']",description="Machine object associated to this ElementalHost (through ElementalMachine)"
+//+kubebuilder:printcolumn:name="ElementalMachine",type="string",JSONPath=".spec.machineRef[?(@.kind==\"ElementalMachine\")].name",description="ElementalMachine object associated to this ElementalHost"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="ElementalHost ready status"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of ElementalHost"
 
 // ElementalHost is the Schema for the elementalhosts API.
 type ElementalHost struct {

--- a/api/v1beta1/elementalhost_types.go
+++ b/api/v1beta1/elementalhost_types.go
@@ -58,8 +58,8 @@ func (h *ElementalHost) SetConditions(conditions clusterv1.Conditions) {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
 //+kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.labels['elementalhost\\.infrastructure\\.cluster\\.x-k8s\\.io/machine-name']",description="Machine object associated to this ElementalHost (through ElementalMachine)"
-//+kubebuilder:printcolumn:name="ElementalMachine",type="string",JSONPath=".spec.machineRef[?(@.kind==\"ElementalMachine\")].name",description="ElementalMachine object associated to this ElementalHost"
-//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="ElementalHost ready status"
+//+kubebuilder:printcolumn:name="ElementalMachine",type="string",JSONPath=".spec.machineRef.name",description="ElementalMachine object associated to this ElementalHost"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description="ElementalHost ready condition"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of ElementalHost"
 
 // ElementalHost is the Schema for the elementalhosts API.

--- a/api/v1beta1/elementalmachine_types.go
+++ b/api/v1beta1/elementalmachine_types.go
@@ -66,6 +66,11 @@ func (m *ElementalMachine) SetConditions(conditions clusterv1.Conditions) {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
+//+kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this ElementalMachine"
+//+kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="ElementalMachine ready status"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of ElementalMachine"
 
 // ElementalMachine is the Schema for the elementalmachines API.
 type ElementalMachine struct {

--- a/api/v1beta1/elementalmachine_types.go
+++ b/api/v1beta1/elementalmachine_types.go
@@ -69,7 +69,7 @@ func (m *ElementalMachine) SetConditions(conditions clusterv1.Conditions) {
 //+kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
 //+kubebuilder:printcolumn:name="Machine",type="string",JSONPath=".metadata.ownerReferences[?(@.kind==\"Machine\")].name",description="Machine object which owns with this ElementalMachine"
 //+kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
-//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="ElementalMachine ready status"
+//+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description="ElementalMachine ready condition"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of ElementalMachine"
 
 // ElementalMachine is the Schema for the elementalmachines API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elementalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elementalhosts.yaml
@@ -21,14 +21,14 @@ spec:
       type: string
     - description: Machine object associated to this ElementalHost (through ElementalMachine)
       jsonPath: .metadata.labels['elementalhost\.infrastructure\.cluster\.x-k8s\.io/machine-name']
-      name: ElementalMachine
+      name: Machine
       type: string
     - description: ElementalMachine object associated to this ElementalHost
-      jsonPath: .spec.machineRef[?(@.kind=="ElementalMachine")].name
+      jsonPath: .spec.machineRef.name
       name: ElementalMachine
       type: string
-    - description: ElementalHost ready status
-      jsonPath: .status.ready
+    - description: ElementalHost ready condition
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
     - description: Time duration since creation of ElementalHost

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elementalhosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elementalhosts.yaml
@@ -14,7 +14,28 @@ spec:
     singular: elementalhost
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Machine object associated to this ElementalHost (through ElementalMachine)
+      jsonPath: .metadata.labels['elementalhost\.infrastructure\.cluster\.x-k8s\.io/machine-name']
+      name: ElementalMachine
+      type: string
+    - description: ElementalMachine object associated to this ElementalHost
+      jsonPath: .spec.machineRef[?(@.kind=="ElementalMachine")].name
+      name: ElementalMachine
+      type: string
+    - description: ElementalHost ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Time duration since creation of ElementalHost
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ElementalHost is the Schema for the elementalhosts API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elementalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elementalmachines.yaml
@@ -14,7 +14,28 @@ spec:
     singular: elementalmachine
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Machine object which owns with this ElementalMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: ElementalMachine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Time duration since creation of ElementalMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ElementalMachine is the Schema for the elementalmachines API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_elementalmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_elementalmachines.yaml
@@ -27,8 +27,8 @@ spec:
       jsonPath: .spec.providerID
       name: ProviderID
       type: string
-    - description: ElementalMachine ready status
-      jsonPath: .status.ready
+    - description: ElementalMachine ready condition
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
     - description: Time duration since creation of ElementalMachine

--- a/infrastructure-elemental/v0.0.0/infrastructure-components.yaml
+++ b/infrastructure-elemental/v0.0.0/infrastructure-components.yaml
@@ -249,7 +249,28 @@ spec:
     singular: elementalhost
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Machine object associated to this ElementalHost (through ElementalMachine)
+      jsonPath: .metadata.labels['elementalhost\.infrastructure\.cluster\.x-k8s\.io/machine-name']
+      name: Machine
+      type: string
+    - description: ElementalMachine object associated to this ElementalHost
+      jsonPath: .spec.machineRef.name
+      name: ElementalMachine
+      type: string
+    - description: ElementalHost ready condition
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Time duration since creation of ElementalHost
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ElementalHost is the Schema for the elementalhosts API.
@@ -444,7 +465,28 @@ spec:
     singular: elementalmachine
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Machine object which owns with this ElementalMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: ElementalMachine ready condition
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Time duration since creation of ElementalMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ElementalMachine is the Schema for the elementalmachines API.

--- a/internal/controller/elementalmachine_controller.go
+++ b/internal/controller/elementalmachine_controller.go
@@ -583,7 +583,6 @@ func (r *ElementalMachineReconciler) associateElementalHost(ctx context.Context,
 	}
 
 	// Link the ElementalHost to ElementalMachine
-	elementalHostCandidate.Labels[infrastructurev1beta1.LabelElementalHostMachineName] = elementalMachine.Name
 	elementalHostCandidate.Spec.MachineRef = &corev1.ObjectReference{
 		APIVersion: elementalMachine.APIVersion,
 		Kind:       elementalMachine.Kind,
@@ -599,7 +598,13 @@ func (r *ElementalMachineReconciler) associateElementalHost(ctx context.Context,
 		Name:      *machine.Spec.Bootstrap.DataSecretName,
 	}
 
-	// TODO: Decorate the ElementalHost with useful labels, for example the Cluster name, Control Plane endpoint, etc.
+	// Propagate the Machine name to ElementalHost
+	elementalHostCandidate.Labels[infrastructurev1beta1.LabelElementalHostMachineName] = machine.Name
+
+	// Propagate the Cluster name to ElementalHost
+	if name, ok := elementalMachine.Labels[clusterv1.ClusterNameLabel]; ok {
+		elementalHostCandidate.Labels[clusterv1.ClusterNameLabel] = name
+	}
 
 	// Reconciliation step #10: Set status.addresses to the provider-specific set of instance addresses
 	// TODO: Fetch the addresses from ElementalHost to update the associated ElementalMachine

--- a/internal/controller/elementalmachine_controller_test.go
+++ b/internal/controller/elementalmachine_controller_test.go
@@ -49,7 +49,7 @@ var _ = Describe("ElementalMachine controller association", Label("controller", 
 	}
 	machine := clusterv1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
+			Name:      "machine-test",
 			Namespace: namespace.Name,
 		},
 		Spec: clusterv1.MachineSpec{
@@ -62,9 +62,9 @@ var _ = Describe("ElementalMachine controller association", Label("controller", 
 	// ElementalMachine owned by the CAPI Machine (ownership set after creation in BeforeAll())
 	elementalMachine := v1beta1.ElementalMachine{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
+			Name:      "elemental-machine-test",
 			Namespace: namespace.Name,
-			Labels:    map[string]string{"cluster.x-k8s.io/cluster-name": cluster.Name},
+			Labels:    map[string]string{clusterv1.ClusterNameLabel: cluster.Name},
 		},
 	}
 
@@ -157,7 +157,8 @@ var _ = Describe("ElementalMachine controller association", Label("controller", 
 			Name:      installedHost.Name,
 			Namespace: installedHost.Namespace,
 		}, &installedHost)).Should(Succeed())
-		Expect(installedHost.Labels[v1beta1.LabelElementalHostMachineName]).Should(Equal(elementalMachine.Name), "machine-name label must be set")
+		Expect(installedHost.Labels[v1beta1.LabelElementalHostMachineName]).Should(Equal(machine.Name), "machine-name label must be set")
+		Expect(installedHost.Labels[clusterv1.ClusterNameLabel]).Should(Equal(cluster.Name), "cluster name label must be set")
 	})
 	It("should not mark machine as ready until cluster's controlplane is initialized ", func() {
 		// Mark the host as bootstrapped


### PR DESCRIPTION
Closes #44 

This adds more display information:
```
# kubectl get machines && kubectl get elementalmachines && kubectl get elementalhosts
NAME                                        CLUSTER                 NODENAME                                 PROVIDERID                                                   PHASE     AGE   VERSION
elemental-cluster-k3s-control-plane-6mw2p   elemental-cluster-k3s   m-d9e3bb70-3a82-4f01-8bcd-e5a6d6b5f67d   elemental://default/m-d9e3bb70-3a82-4f01-8bcd-e5a6d6b5f67d   Running   14m   v1.28.5+k3s1
NAME                                        CLUSTER                 MACHINE                                     PROVIDERID                                                   READY   AGE
elemental-cluster-k3s-control-plane-q2td6   elemental-cluster-k3s   elemental-cluster-k3s-control-plane-6mw2p   elemental://default/m-d9e3bb70-3a82-4f01-8bcd-e5a6d6b5f67d   True    14m
NAME                                     CLUSTER                 MACHINE                                     ELEMENTALMACHINE                            READY   AGE
m-d9e3bb70-3a82-4f01-8bcd-e5a6d6b5f67d   elemental-cluster-k3s   elemental-cluster-k3s-control-plane-6mw2p   elemental-cluster-k3s-control-plane-q2td6   True    13m
```

Note that there is a sneaky change too. 
The `machine-name` label used on hosts now reflects the CAPI Machine name, and not the ElementalMachine name as previously.
Functionally this does not have any effect, the controller only checks whether the label exists when finding host candidates, the value does not matter.

Since the ElementalMachine is already referenced in the Host spec, I thought it would be nice to use the machine-name label to propagate the CAPI machine name instead.