### PR TITLE
Actualize RKE2 templates

### DIFF
--- a/infrastructure-elemental/v0.0.0/cluster-template-rke2-clusterclass.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-rke2-clusterclass.yaml
@@ -15,13 +15,13 @@ spec:
     serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
   topology:
     class: rke2
-    version: "v${KUBERNETES_VERSION:=1.28.5}+rke2r1"
+    version: "v${KUBERNETES_VERSION:=1.30.1}+rke2r1"
     controlPlane:
       metadata: {}
       replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
     workers:
       machineDeployments:
-      - class: k3s-default-worker
+      - class: rke2-default-worker
         name: md-0
         replicas: ${WORKER_MACHINE_COUNT:=1}
     variables:
@@ -29,7 +29,6 @@ spec:
       value: ${CONTROL_PLANE_ENDPOINT_HOST:=""}
     - name: controlPlaneEndpointPort
       value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}
-    - name: rke2Version
-      value: "v${KUBERNETES_VERSION:=1.28.5}+rke2r1"
     - name: vipInterface
       value: ${VIP_INTERFACE:=eth0}
+

--- a/infrastructure-elemental/v0.0.0/cluster-template-rke2.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-rke2.yaml
@@ -1,13 +1,11 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: RKE2ConfigTemplate
 metadata:
   namespace: ${NAMESPACE}
   name: ${CLUSTER_NAME}-md-0
 spec: 
   template:
-    spec:
-      agentConfig:
-        version: "v${KUBERNETES_VERSION:=1.28.5}+rke2r1"
+    spec: {}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -25,7 +23,7 @@ spec:
       cidrBlocks: ${POD_CIDR:=["10.244.0.0/16"]}
     serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
     name: ${CLUSTER_NAME}-control-plane
   infrastructureRef:
@@ -50,7 +48,7 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: RKE2ConfigTemplate
           name: ${CLUSTER_NAME}-md-0
       clusterName: ${CLUSTER_NAME}
@@ -58,17 +56,16 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: ElementalMachineTemplate
         name: ${CLUSTER_NAME}-md-0
-      version: "v${KUBERNETES_VERSION:=1.28.5}+rke2r1"
+      version: "v${KUBERNETES_VERSION:=1.30.1}+rke2r1"
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: ${CLUSTER_NAME}-control-plane
   namespace: ${NAMESPACE}
 spec: 
   replicas: 1
-  agentConfig:
-    version: "v${KUBERNETES_VERSION:=1.28.5}+rke2r1"
+  version: "v${KUBERNETES_VERSION:=1.30.1}+rke2r1"
   serverConfig:
     disableComponents:
       kubernetesComponents:
@@ -80,42 +77,11 @@ spec:
   nodeDrainTimeout: 2m
   registrationMethod: "address"
   registrationAddress: "${CONTROL_PLANE_ENDPOINT_HOST}"
+  rolloutStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxSurge: 1
   files:
-  - path: /var/lib/rancher/rke2/server/manifests/kube-vip-rbac.yaml
-    content: |
-      apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: kube-vip
-        namespace: kube-system
-      ---
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        annotations:
-          rbac.authorization.kubernetes.io/autoupdate: "true"
-        name: system:kube-vip-role
-      rules:
-        - apiGroups: [""]
-          resources: ["services", "services/status", "nodes", "endpoints"]
-          verbs: ["list","get","watch", "update"]
-        - apiGroups: ["coordination.k8s.io"]
-          resources: ["leases"]
-          verbs: ["list", "get", "watch", "update", "create"]
-      ---
-      kind: ClusterRoleBinding
-      apiVersion: rbac.authorization.k8s.io/v1
-      metadata:
-        name: system:kube-vip-binding
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: system:kube-vip-role
-      subjects:
-      - kind: ServiceAccount
-        name: kube-vip
-        namespace: kube-system
-    owner: root:root
   - path: /var/lib/rancher/rke2/server/manifests/kube-vip.yaml
     content: |
       apiVersion: v1
@@ -133,20 +99,28 @@ spec:
             value: "true"
           - name: port
             value: "${CONTROL_PLANE_ENDPOINT_PORT:=6443}"
+          - name: vip_nodename
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: vip_interface
             value: ${VIP_INTERFACE:=eth0}
           - name: vip_cidr
             value: "32"
+          - name: dns_mode
+            value: first
           - name: cp_enable
             value: "true"
           - name: cp_namespace
             value: kube-system
-          - name: vip_ddns
-            value: "false"
           - name: svc_enable
             value: "true"
+          - name: svc_leasename
+            value: plndr-svcs-lock
           - name: vip_leaderelection
             value: "true"
+          - name: vip_leasename
+            value: plndr-cp-lock
           - name: vip_leaseduration
             value: "5"
           - name: vip_renewdeadline
@@ -155,8 +129,10 @@ spec:
             value: "1"
           - name: address
             value: ${CONTROL_PLANE_ENDPOINT_HOST}
-          image: ghcr.io/kube-vip/kube-vip:v0.6.4
-          imagePullPolicy: Always
+          - name: prometheus_server
+            value: :2112
+          image: ghcr.io/kube-vip/kube-vip:v0.8.0
+          imagePullPolicy: IfNotPresent
           name: kube-vip
           resources: {}
           securityContext:
@@ -164,7 +140,6 @@ spec:
               add:
               - NET_ADMIN
               - NET_RAW
-              - SYS_TIME
           volumeMounts:
           - mountPath: /etc/kubernetes/admin.conf
             name: kubeconfig
@@ -175,7 +150,7 @@ spec:
         hostNetwork: true
         volumes:
         - hostPath:
-            path: /etc/rancher/rke2/rke2.yaml 
+            path: /etc/rancher/rke2/rke2.yaml
           name: kubeconfig
       status: {}
     owner: root:root

--- a/infrastructure-elemental/v0.0.0/clusterclass-rke2.yaml
+++ b/infrastructure-elemental/v0.0.0/clusterclass-rke2.yaml
@@ -44,12 +44,12 @@ spec:
         openAPIV3Schema:
           type: integer
           default: 6443
-    - name: rke2Version
+    - name: vipInterface
       required: true
       schema:
         openAPIV3Schema:
           type: string
-          default: "v1.28.5+rke2r1"
+          default: "eth0"
   patches:
     - name: elementalClusterTemplate
       definitions:
@@ -76,52 +76,9 @@ spec:
               controlPlane: true
           jsonPatches:
             - op: add
-              path: "/spec/template/spec/agentConfig/version"
-              valueFrom:
-                variable: rke2Version
-            - op: add
               path: "/spec/template/spec/registrationAddress"
               valueFrom:
                 variable: controlPlaneEndpointHost
-            - op: add
-              path: "/spec/template/spec/kubeadmConfigSpec/files"
-              valueFrom:
-                template: |
-                  - content: |
-                      apiVersion: v1
-                      kind: ServiceAccount
-                      metadata:
-                        name: kube-vip
-                        namespace: kube-system
-                      ---
-                      apiVersion: rbac.authorization.k8s.io/v1
-                      kind: ClusterRole
-                      metadata:
-                        annotations:
-                          rbac.authorization.kubernetes.io/autoupdate: "true"
-                        name: system:kube-vip-role
-                      rules:
-                        - apiGroups: [""]
-                          resources: ["services", "services/status", "nodes", "endpoints"]
-                          verbs: ["list","get","watch", "update"]
-                        - apiGroups: ["coordination.k8s.io"]
-                          resources: ["leases"]
-                          verbs: ["list", "get", "watch", "update", "create"]
-                      ---
-                      kind: ClusterRoleBinding
-                      apiVersion: rbac.authorization.k8s.io/v1
-                      metadata:
-                        name: system:kube-vip-binding
-                      roleRef:
-                        apiGroup: rbac.authorization.k8s.io
-                        kind: ClusterRole
-                        name: system:kube-vip-role
-                      subjects:
-                      - kind: ServiceAccount
-                        name: kube-vip
-                        namespace: kube-system
-                    owner: root:root
-                    path: /var/lib/rancher/rke2/server/manifests/kube-vip-rbac.yaml
             - op: add
               path: "/spec/template/spec/kubeadmConfigSpec/files"
               valueFrom:
@@ -142,20 +99,28 @@ spec:
                             value: "true"
                           - name: port
                             value: {{ .controlPlaneEndpointPort }}
+                          - name: vip_nodename
+                            valueFrom:
+                              fieldRef:
+                                fieldPath: spec.nodeName
                           - name: vip_interface
                             value: {{ .vipInterface }}
                           - name: vip_cidr
                             value: "32"
+                          - name: dns_mode
+                            value: first
                           - name: cp_enable
                             value: "true"
                           - name: cp_namespace
                             value: kube-system
-                          - name: vip_ddns
-                            value: "false"
                           - name: svc_enable
                             value: "true"
+                          - name: svc_leasename
+                            value: plndr-svcs-lock
                           - name: vip_leaderelection
                             value: "true"
+                          - name: vip_leasename
+                            value: plndr-cp-lock
                           - name: vip_leaseduration
                             value: "5"
                           - name: vip_renewdeadline
@@ -164,8 +129,10 @@ spec:
                             value: "1"
                           - name: address
                             value: {{ .controlPlaneEndpointHost }}
-                          image: ghcr.io/kube-vip/kube-vip:v0.6.4
-                          imagePullPolicy: Always
+                          - name: prometheus_server
+                            value: :2112
+                          image: ghcr.io/kube-vip/kube-vip:v0.8.0
+                          imagePullPolicy: IfNotPresent
                           name: kube-vip
                           resources: {}
                           securityContext:
@@ -173,7 +140,6 @@ spec:
                               add:
                               - NET_ADMIN
                               - NET_RAW
-                              - SYS_TIME
                           volumeMounts:
                           - mountPath: /etc/kubernetes/admin.conf
                             name: kubeconfig
@@ -209,12 +175,15 @@ spec:
   template:
     spec:
       serverConfig:
-        cni: calico
         disableComponents:
           kubernetesComponents:
             - cloudController
       nodeDrainTimeout: 2m
       registrationMethod: "address"
+      rolloutStrategy:
+        type: "RollingUpdate"
+        rollingUpdate:
+          maxSurge: 1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElementalMachineTemplate

--- a/test/scripts/apply_all_templates.sh
+++ b/test/scripts/apply_all_templates.sh
@@ -100,21 +100,21 @@ rke2 > $MANIFEST_RKE2
 kubectl create namespace $MANIFEST_RKE2_NAMESPACE
 kubectl apply -f $MANIFEST_RKE2
 
-# rke2 clusterclass
-printf "\n##### rke2-clusterclass #####\n"
-MANIFEST_RKE2_CLUSTERCLASS="$MANIFESTS_DIR/rke2-clusterclass.yaml"
-MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE="rke2-clusterclass"
-kubectl delete namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE --ignore-not-found
-clusterctl generate cluster --config $CONFIG_FILE \
---control-plane-machine-count=1 \
---worker-machine-count=1 \
---infrastructure elemental:$PROVIDER_VERSION \
---target-namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE \
---flavor rke2-clusterclass \
---v $LOG_LEVEL \
-rke2-clusterclass > $MANIFEST_RKE2_CLUSTERCLASS
-kubectl create namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE
-kubectl apply -f $MANIFEST_RKE2_CLUSTERCLASS
+# rke2 clusterclass not supported upstream yet
+# printf "\n##### rke2-clusterclass #####\n"
+# MANIFEST_RKE2_CLUSTERCLASS="$MANIFESTS_DIR/rke2-clusterclass.yaml"
+# MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE="rke2-clusterclass"
+# kubectl delete namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE --ignore-not-found
+# clusterctl generate cluster --config $CONFIG_FILE \
+# --control-plane-machine-count=1 \
+# --worker-machine-count=1 \
+# --infrastructure elemental:$PROVIDER_VERSION \
+# --target-namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE \
+# --flavor rke2-clusterclass \
+# --v $LOG_LEVEL \
+# rke2-clusterclass > $MANIFEST_RKE2_CLUSTERCLASS
+# kubectl create namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE
+# kubectl apply -f $MANIFEST_RKE2_CLUSTERCLASS
 
 # kubeadm
 printf "\n##### kubeadm #####\n"

--- a/test/scripts/apply_all_templates.sh
+++ b/test/scripts/apply_all_templates.sh
@@ -100,21 +100,21 @@ rke2 > $MANIFEST_RKE2
 kubectl create namespace $MANIFEST_RKE2_NAMESPACE
 kubectl apply -f $MANIFEST_RKE2
 
-## rke2 clusterclass not supported upstream yet
-# printf "\n##### rke2-clusterclass #####\n"
-# MANIFEST_RKE2_CLUSTERCLASS="$MANIFESTS_DIR/rke2-clusterclass.yaml"
-# MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE="rke2-clusterclass"
-# kubectl delete namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE --ignore-not-found
-# clusterctl generate cluster --config $CONFIG_FILE \
-# --control-plane-machine-count=1 \
-# --worker-machine-count=1 \
-# --infrastructure elemental:$PROVIDER_VERSION \
-# --target-namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE \
-# --flavor rke2-clusterclass \
-# --v $LOG_LEVEL \
-# rke2-clusterclass > $MANIFEST_RKE2_CLUSTERCLASS
-# kubectl create namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE
-# kubectl apply -f $MANIFEST_RKE2_CLUSTERCLASS
+# rke2 clusterclass
+printf "\n##### rke2-clusterclass #####\n"
+MANIFEST_RKE2_CLUSTERCLASS="$MANIFESTS_DIR/rke2-clusterclass.yaml"
+MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE="rke2-clusterclass"
+kubectl delete namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE --ignore-not-found
+clusterctl generate cluster --config $CONFIG_FILE \
+--control-plane-machine-count=1 \
+--worker-machine-count=1 \
+--infrastructure elemental:$PROVIDER_VERSION \
+--target-namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE \
+--flavor rke2-clusterclass \
+--v $LOG_LEVEL \
+rke2-clusterclass > $MANIFEST_RKE2_CLUSTERCLASS
+kubectl create namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE
+kubectl apply -f $MANIFEST_RKE2_CLUSTERCLASS
 
 # kubeadm
 printf "\n##### kubeadm #####\n"

--- a/test/scripts/setup_kind_cluster.sh
+++ b/test/scripts/setup_kind_cluster.sh
@@ -6,7 +6,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.26.4
+  image: kindest/node:v1.26.6
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration
@@ -130,7 +130,7 @@ spec:
 EOF
 
 # Wait for registration to be initialized
-kubectl wait --for=condition=ready elementalregistration my-registration
+kubectl wait --for=condition=ready elementalregistration my-registration --timeout=120s
 
 # Print the agent config
 cd "$(dirname "$0")"


### PR DESCRIPTION
Since `1.3.0` version of the RKE2 provider supports ClusterClasses, it's a good time to refresh the templates and also use the newer v1beta1 API as well.