### PR TITLE
Fix RKE2 ClusterClass and RKE2 default registration method

### DIFF
--- a/infrastructure-elemental/v0.0.0/cluster-template-rke2.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-rke2.yaml
@@ -75,8 +75,7 @@ spec:
     kind: ElementalMachineTemplate
     name: ${CLUSTER_NAME}-control-plane
   nodeDrainTimeout: 2m
-  registrationMethod: "address"
-  registrationAddress: "${CONTROL_PLANE_ENDPOINT_HOST}"
+  registrationMethod: "control-plane-endpoint"
   rolloutStrategy:
     type: "RollingUpdate"
     rollingUpdate:

--- a/infrastructure-elemental/v0.0.0/clusterclass-rke2.yaml
+++ b/infrastructure-elemental/v0.0.0/clusterclass-rke2.yaml
@@ -76,10 +76,6 @@ spec:
               controlPlane: true
           jsonPatches:
             - op: add
-              path: "/spec/template/spec/registrationAddress"
-              valueFrom:
-                variable: controlPlaneEndpointHost
-            - op: add
               path: "/spec/template/spec/kubeadmConfigSpec/files"
               valueFrom:
                 template: |
@@ -174,12 +170,16 @@ metadata:
 spec:
   template:
     spec:
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: ElementalMachineTemplate
+        name: rke2-control-plane
       serverConfig:
         disableComponents:
           kubernetesComponents:
             - cloudController
       nodeDrainTimeout: 2m
-      registrationMethod: "address"
+      registrationMethod: "control-plane-endpoint"
       rolloutStrategy:
         type: "RollingUpdate"
         rollingUpdate:


### PR DESCRIPTION
Adding the `infrastructureRef` to the RKE2ControlPlaneTemplate is a workaround for [this](https://github.com/rancher-sandbox/cluster-api-provider-rke2/issues/341) issue. 
I tested it against a local fresh build of the RKE2 provider, the Cluster Class should work on a next RKE2 provider release.

Also edited the `registrationMethod` to use `control-plane-endpoint`, since it's equivalent than using address and using the control plane endpoint address. 