### PR TITLE
Dockerfiles: ensure /usr/libexec is present on the image FS

### DIFF
--- a/Dockerfile.kubeadm.os
+++ b/Dockerfile.kubeadm.os
@@ -117,6 +117,10 @@ COPY --from=AGENT /workspace/dummy.so /usr/lib/elemental/plugins/dummy.so
 # Add framework files
 COPY framework/files/ /
 
+# Ensure permanent paths in the framework files mounted on read only base dirs are
+# present on the image file system
+RUN mkdir -p /usr/libexec
+
 # Add agent config
 COPY $AGENT_CONFIG_FILE /oem/elemental/agent/config.yaml
 

--- a/Dockerfile.os
+++ b/Dockerfile.os
@@ -103,6 +103,10 @@ COPY --from=AGENT /workspace/dummy.so /usr/lib/elemental/plugins/dummy.so
 # Add framework files
 COPY framework/files/ /
 
+# Ensure permanent paths in the framework files mounted on read only base dirs are
+# present on the image file system
+RUN mkdir -p /usr/libexec
+
 # Add agent config
 COPY $AGENT_CONFIG_FILE /oem/elemental/agent/config.yaml
 


### PR DESCRIPTION
Since we are going to mount /usr/libexec as a permanent path and since /usr is a read only path, we need /usr/libexec to exist in the base image, otherwise the whole rootfs stage in `framework/files/system/oem/01_elemental-rootfs.yaml` would fail, causing the persistent paths not already processed to not be persisted at all.