### PR TITLE
Prevent associating multiple ElementalHosts

### DIFF
--- a/api/v1beta1/constants.go
+++ b/api/v1beta1/constants.go
@@ -29,11 +29,12 @@ const (
 
 // Labels.
 const (
-	LabelElementalHostMachineName  = "elementalhost.infrastructure.cluster.x-k8s.io/machine-name"
-	LabelElementalHostInstalled    = "elementalhost.infrastructure.cluster.x-k8s.io/installed"
-	LabelElementalHostBootstrapped = "elementalhost.infrastructure.cluster.x-k8s.io/bootstrapped"
-	LabelElementalHostNeedsReset   = "elementalhost.infrastructure.cluster.x-k8s.io/needs-reset"
-	LabelElementalHostReset        = "elementalhost.infrastructure.cluster.x-k8s.io/reset"
+	LabelElementalHostMachineName          = "elementalhost.infrastructure.cluster.x-k8s.io/machine-name"
+	LabelElementalHostElementalMachineName = "elementalhost.infrastructure.cluster.x-k8s.io/elemental-machine-name"
+	LabelElementalHostInstalled            = "elementalhost.infrastructure.cluster.x-k8s.io/installed"
+	LabelElementalHostBootstrapped         = "elementalhost.infrastructure.cluster.x-k8s.io/bootstrapped"
+	LabelElementalHostNeedsReset           = "elementalhost.infrastructure.cluster.x-k8s.io/needs-reset"
+	LabelElementalHostReset                = "elementalhost.infrastructure.cluster.x-k8s.io/reset"
 )
 
 // HostPhases.

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -140,7 +140,7 @@ func setupAllWithManager(k8sManager manager.Manager) {
 		Client:        k8sManager.GetClient(),
 		Scheme:        k8sManager.GetScheme(),
 		Tracker:       remoteTrackerMock,
-		RequeuePeriod: time.Millisecond,
+		RequeuePeriod: time.Second,
 	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Props to @juadk for finding this corner case.

For context, the ElementalMachine <--> ElementalHost association works like the following, from the ElementalMachineController perspective:

1. Patch the ElementalHost candidate to reference the ElementalMachine (ElementalHost --> ElementalMachine)
2. Patch the ElementalMachine to reference the ElementalHost candidate (ElementalMachine --> ElementalHost)

It can happen that 2. fails after 1. succeeds, this will lead to another ElementalMachine reconcile loop, where we are going to find a new ElementalHost. The one already linked is going to be excluded from a followup search, since it's already labeled as associated.

It will look like this, where the same ElementalMachine is associated to 2 (or more) ElementalHosts:

```
gh-runner@elemental-e2e-ci-379bc19f05ef448dae0f2808ee53cec9:~> kubectl get elementalhosts -A
NAMESPACE   NAME       CLUSTER             MACHINE                                 ELEMENTALMACHINE                        PHASE     READY   AGE
default     node-001   elemental-cluster   elemental-cluster-control-plane-df69z   elemental-cluster-control-plane-x7g5d   Running   True    8m14s
default     node-003   elemental-cluster   elemental-cluster-md-0-tdtqm-pzpk6      elemental-cluster-md-0-tdtqm-pzpk6      Running   True    8m14s
default     node-002   elemental-cluster   elemental-cluster-md-0-tdtqm-pzpk6      elemental-cluster-md-0-tdtqm-pzpk6      Running   True    8m14s
```

This patch introduces a prior lookup to find any already-linked ElementalHost, and use it as a candidate to finalize association.