### PR TITLE
Fix missing mtools dependency

### DIFF
--- a/Dockerfile.kubeadm.os
+++ b/Dockerfile.kubeadm.os
@@ -88,7 +88,9 @@ RUN ARCH=$(uname -m); \
       sed \
       patch \
       iproute2 \
-      shim 
+      shim \
+      # glibc-gconv-modules-extra still missing from mtools required
+      glibc-gconv-modules-extra 
 
 # Install kubeadm stack dependencies
 RUN ARCH=$(uname -m); \


### PR DESCRIPTION
This should fix the mcopy issues we are currently experiencing in Tumbleweed: 

```
INFO[2024-06-25T10:29:52Z] Creating EFI image...                        
INFO[2024-06-25T10:29:52Z] Creating image /tmp/elemental-iso797118833/uefi.img from rootDir  
DEBU[2024-06-25T10:29:52Z] Running cmd: 'mkfs.vfat -n COS_GRUB /tmp/elemental-iso797118833/uefi.img' 
DEBU[2024-06-25T10:29:52Z] Running cmd: 'mcopy -s -i /tmp/elemental-iso797118833/uefi.img /tmp/elemental-iso797118833/uefi/EFI ::' 
DEBU[2024-06-25T10:29:52Z] 'mcopy' command reported an error: exit status 1 
DEBU[2024-06-25T10:29:52Z] 'mcopy' command output: Error converting to codepage 850 Invalid argument
Error setting code page
Cannot initialize '::'
::: Invalid argument 
make: *** [Makefile:286: build-iso-kubeadm] Error 1
Error: Process completed with exit code 2.
```