### PR TITLE
Actualyze elemental init arguments and improve iso build setup

### DIFF
--- a/Dockerfile.iso
+++ b/Dockerfile.iso
@@ -1,0 +1,13 @@
+ARG ELEMENTAL_OS_IMAGE
+
+FROM ${ELEMENTAL_OS_IMAGE} as os
+FROM ${ELEMENTAL_OS_IMAGE} as builder
+
+COPY iso/config/manifest.yaml manifest.yaml
+COPY --from=os / rootfs
+
+RUN elemental --debug --config-dir . build-iso -o /output -n "elemental-dev" dir:rootfs
+
+FROM busybox:stable
+
+COPY --from=builder /output /elemental-iso

--- a/Dockerfile.kubeadm.iso
+++ b/Dockerfile.kubeadm.iso
@@ -1,0 +1,13 @@
+ARG ELEMENTAL_OS_IMAGE
+
+FROM ${ELEMENTAL_OS_IMAGE} as os
+FROM ${ELEMENTAL_OS_IMAGE} as builder
+
+COPY iso/config/manifest.yaml manifest.yaml
+COPY --from=os / rootfs
+
+RUN elemental --debug --config-dir . build-iso -o /output -n "elemental-dev-kubeadm" dir:rootfs
+
+FROM busybox:stable
+
+COPY --from=builder /output /elemental-iso

--- a/Dockerfile.kubeadm.os
+++ b/Dockerfile.kubeadm.os
@@ -51,8 +51,6 @@ FROM registry.opensuse.org/opensuse/tumbleweed:latest as OS
 
 ARG AGENT_CONFIG_FILE=iso/config/example-config.yaml
 
-COPY iso/config/manifest.yaml manifest.yaml
-
 # install kernel, systemd, dracut, grub2 and other required tools
 RUN ARCH=$(uname -m); \
     if [[ $ARCH == "aarch64" ]]; then ARCH="arm64"; fi; \
@@ -133,7 +131,7 @@ RUN systemctl enable NetworkManager.service sshd conntrackd containerd kubelet
 RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
 
 # Generate initrd with required elemental services
-RUN elemental --debug init --force
+RUN elemental init --force elemental-rootfs,elemental-sysroot,grub-config,dracut-config,cloud-config-essentials,elemental-setup,boot-assessment
 
 # Update os-release file with some metadata
 RUN echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release && \

--- a/Dockerfile.os
+++ b/Dockerfile.os
@@ -51,8 +51,6 @@ FROM registry.opensuse.org/opensuse/leap:15.5 as OS
 
 ARG AGENT_CONFIG_FILE=iso/config/example-config.yaml
 
-COPY iso/config/manifest.yaml manifest.yaml
-
 # install kernel, systemd, dracut, grub2 and other required tools
 RUN ARCH=$(uname -m); \
     if [[ $ARCH == "aarch64" ]]; then ARCH="arm64"; fi; \
@@ -117,12 +115,7 @@ RUN systemctl enable NetworkManager.service sshd
 RUN cp /usr/share/systemd/tmp.mount /etc/systemd/system
 
 # Generate initrd with required elemental services
-RUN elemental init -f && \
-    kernel=$(ls /boot/Image-* | head -n1) && \
-    if [ -e "$kernel" ]; then ln -sf "${kernel#/boot/}" /boot/vmlinuz; fi && \
-    rm -rf /var/log/update* && \
-    >/var/log/lastlog && \
-    rm -rf /boot/vmlinux*
+RUN elemental init --force elemental-rootfs,elemental-sysroot,grub-config,dracut-config,cloud-config-essentials,elemental-setup,boot-assessment
 
 # Update os-release file with some metadata
 RUN echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release && \

--- a/Makefile
+++ b/Makefile
@@ -264,10 +264,13 @@ endif
 
 .PHONY: build-iso
 build-iso: build-os
-	$(CONTAINER_TOOL) run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ./iso:/iso \
-		--entrypoint /usr/bin/elemental docker.io/library/elemental-os:dev \
-		--config-dir . --debug build-iso -n elemental-dev \
-		--local -o /iso docker.io/library/elemental-os:dev
+	$(CONTAINER_TOOL) build \
+			--build-arg ELEMENTAL_OS_IMAGE=docker.io/library/elemental-os:dev \
+			-t docker.io/library/elemental-iso:dev \
+			-f Dockerfile.iso .
+	$(CONTAINER_TOOL) run -v ./iso:/iso \
+			--entrypoint cp docker.io/library/elemental-iso:dev \
+			-r /elemental-iso/. /iso
 
 .PHONY: build-os-kubeadm
 build-os-kubeadm: 
@@ -283,10 +286,13 @@ endif
 
 .PHONY: build-iso-kubeadm
 build-iso-kubeadm: build-os-kubeadm
-	$(CONTAINER_TOOL) run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ./iso:/iso \
-		--entrypoint /usr/bin/elemental docker.io/library/elemental-os:dev-kubeadm \
-		--config-dir . --debug build-iso -n elemental-dev-kubeadm \
-		--local -o /iso docker.io/library/elemental-os:dev-kubeadm
+	$(CONTAINER_TOOL) build \
+			--build-arg ELEMENTAL_OS_IMAGE=docker.io/library/elemental-os:dev-kubeadm \
+			-t docker.io/library/elemental-iso:dev-kubeadm \
+			-f Dockerfile.kubeadm.iso .
+	$(CONTAINER_TOOL) run -v ./iso:/iso \
+			--entrypoint cp docker.io/library/elemental-iso:dev-kubeadm \
+			-r /elemental-iso/. /iso
 
 .PHONY: update-test-capi-crds
 update-test-capi-crds: 


### PR DESCRIPTION
A bit of improvements. 
First of all the `elemental init` command has been updated to work with the newer 2.1.0 version that we included.

Second the iso build now happens in a container and not anymore from a running FS. The previous setup was error prone. 
Now it's aligned to how we build dev ISOs in the Elemental project.