### PR TITLE
Only use essential elemental services

### DIFF
--- a/Dockerfile.kubeadm.os
+++ b/Dockerfile.kubeadm.os
@@ -87,6 +87,9 @@ RUN ARCH=$(uname -m); \
       patch \
       iproute2 \
       shim \
+      btrfsprogs \
+      btrfsmaintenance \
+      snapper \
       # glibc-gconv-modules-extra still missing from mtools required
       glibc-gconv-modules-extra 
 
@@ -117,21 +120,14 @@ COPY --from=AGENT /workspace/dummy.so /usr/lib/elemental/plugins/dummy.so
 # Add framework files
 COPY framework/files/ /
 
-# Ensure permanent paths in the framework files mounted on read only base dirs are
-# present on the image file system
-RUN mkdir -p /usr/libexec
-
 # Add agent config
 COPY $AGENT_CONFIG_FILE /oem/elemental/agent/config.yaml
 
 # Enable essential services
 RUN systemctl enable NetworkManager.service sshd conntrackd containerd kubelet
 
-# This is for automatic testing purposes, do not do this in production.
-RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
-
 # Generate initrd with required elemental services
-RUN elemental init --force elemental-rootfs,elemental-sysroot,grub-config,dracut-config,cloud-config-essentials,elemental-setup,boot-assessment
+RUN elemental init --debug --force
 
 # Update os-release file with some metadata
 RUN echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release && \

--- a/Dockerfile.kubeadm.os
+++ b/Dockerfile.kubeadm.os
@@ -126,6 +126,9 @@ COPY $AGENT_CONFIG_FILE /oem/elemental/agent/config.yaml
 # Enable essential services
 RUN systemctl enable NetworkManager.service sshd conntrackd containerd kubelet
 
+# This is for automatic testing purposes, do not do this in production.
+RUN echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/rootlogin.conf
+
 # Generate initrd with required elemental services
 RUN elemental init --debug --force
 

--- a/Dockerfile.os
+++ b/Dockerfile.os
@@ -101,10 +101,6 @@ COPY --from=AGENT /workspace/dummy.so /usr/lib/elemental/plugins/dummy.so
 # Add framework files
 COPY framework/files/ /
 
-# Ensure permanent paths in the framework files mounted on read only base dirs are
-# present on the image file system
-RUN mkdir -p /usr/libexec
-
 # Add agent config
 COPY $AGENT_CONFIG_FILE /oem/elemental/agent/config.yaml
 
@@ -115,7 +111,7 @@ RUN systemctl enable NetworkManager.service sshd
 RUN cp /usr/share/systemd/tmp.mount /etc/systemd/system
 
 # Generate initrd with required elemental services
-RUN elemental init --force elemental-rootfs,elemental-sysroot,grub-config,dracut-config,cloud-config-essentials,elemental-setup,boot-assessment
+RUN elemental init --debug --force
 
 # Update os-release file with some metadata
 RUN echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release && \

--- a/iso/config/manifest.yaml
+++ b/iso/config/manifest.yaml
@@ -1,6 +1,3 @@
 iso:
   bootloader-in-rootfs: true
-  grub-entry-name: "Elemental Install"
-
-squash-no-compression: true
-
+  grub-entry-name: "Elemental CAPI Install"


### PR DESCRIPTION
This should solve the boot issues post-installation.

Also randomly adding some packages missing in the Kubeadm image to support btrfs snapshotting.