### PR TITLE
Use toolkit nightly builds

### DIFF
--- a/Dockerfile.kubeadm.os
+++ b/Dockerfile.kubeadm.os
@@ -1,4 +1,4 @@
-ARG ELEMENTAL_TOOLKIT=ghcr.io/rancher/elemental-toolkit/elemental-cli:v2.1.0
+ARG ELEMENTAL_TOOLKIT=ghcr.io/rancher/elemental-toolkit/elemental-cli:nightly
 
 FROM registry.opensuse.org/opensuse/leap:15.5 as AGENT
 

--- a/Dockerfile.os
+++ b/Dockerfile.os
@@ -1,4 +1,4 @@
-ARG ELEMENTAL_TOOLKIT=ghcr.io/rancher/elemental-toolkit/elemental-cli:v2.1.0
+ARG ELEMENTAL_TOOLKIT=ghcr.io/rancher/elemental-toolkit/elemental-cli:nightly
 
 FROM registry.opensuse.org/opensuse/leap:15.5 as AGENT
 


### PR DESCRIPTION
This is going to be less stable than before, however the benefit is that we can spot issues early and it makes a lot of sense since we also maintain the toolkit.

This will also fix the mksquashfs issue with always enabled compression. 
With the latest toolkit version compression is disabled by default and installing recovery takes significantly less (from 6 to 1 minute on my machine)