### PR TITLE
Exclude cloud-config-defaults feature

### DIFF
--- a/Dockerfile.kubeadm.os
+++ b/Dockerfile.kubeadm.os
@@ -144,7 +144,8 @@ RUN zypper clean --all && \
     rm -rf /boot/vmlinux*
 
 # Generate initrd with required elemental services
-RUN elemental init --debug --force
+# Features currently excluded: [cloud-config-defaults]
+RUN elemental init --debug --force boot-assessment,cloud-config-essentials,dracut-config,elemental-rootfs,elemental-setup,elemental-sysroot,grub-config,grub-default-bootargs
 
 # Update os-release file with some metadata
 RUN echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release && \

--- a/Dockerfile.os
+++ b/Dockerfile.os
@@ -125,7 +125,8 @@ RUN zypper clean --all && \
 RUN cp /usr/share/systemd/tmp.mount /etc/systemd/system
 
 # Generate initrd with required elemental services
-RUN elemental init --debug --force
+# Features currently excluded: [cloud-config-defaults]
+RUN elemental init --debug --force boot-assessment,cloud-config-essentials,dracut-config,elemental-rootfs,elemental-setup,elemental-sysroot,grub-config,grub-default-bootargs
 
 # Update os-release file with some metadata
 RUN echo TIMESTAMP="`date +'%Y%m%d%H%M%S'`" >> /etc/os-release && \


### PR DESCRIPTION
Excluding the cloud-config-defaults to prevent auto-configuration of `installer` hostname on all hosts.