### PR TITLE
Update k3s manifests

### DIFF
--- a/doc/QUICKSTART.md
+++ b/doc/QUICKSTART.md
@@ -131,7 +131,6 @@
     CONTROL_PLANE_ENDPOINT_HOST=192.168.122.100 clusterctl generate cluster \
     --infrastructure elemental \
     --flavor k3s-single-node \
-    --kubernetes-version 1.28.5 \
     elemental-cluster-k3s > $HOME/elemental-cluster-k3s.yaml
     ```
 
@@ -183,7 +182,7 @@
 
 1. Wait for the `ElementalRegistration` to be ready:
 
-   This will ensure the provider created a new private key to sign Registration tokens and the trust CA Cert is also loaded.    
+   This will ensure the provider created a new private key to sign Registration tokens and the trust CA Cert is also loaded.  
 
    ```bash
    kubectl wait --for=condition=ready elementalregistration my-registration

--- a/infrastructure-elemental/v0.0.0/cluster-template-k3s-clusterclass.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-k3s-clusterclass.yaml
@@ -15,7 +15,7 @@ spec:
     serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
   topology:
     class: k3s
-    version: "v${KUBERNETES_VERSION:=1.28.5}+k3s1"
+    version: "v${KUBERNETES_VERSION:=1.30.2}+k3s1"
     controlPlane:
       metadata: {}
       replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
@@ -30,4 +30,4 @@ spec:
     - name: controlPlaneEndpointPort
       value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}
     - name: k3sVersion
-      value: "v${KUBERNETES_VERSION:=1.28.5}+k3s1"
+      value: "v${KUBERNETES_VERSION:=1.30.2}+k3s1"

--- a/infrastructure-elemental/v0.0.0/cluster-template-k3s-single-node.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-k3s-single-node.yaml
@@ -22,18 +22,19 @@ spec:
     kind: ElementalCluster
     name: ${CLUSTER_NAME}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KThreesControlPlane
 metadata:
   name: ${CLUSTER_NAME}-control-plane
   namespace: ${NAMESPACE}
 spec:
-  infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: ElementalMachineTemplate
-    name: ${CLUSTER_NAME}-control-plane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: ElementalMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
   replicas: 1
-  version: "v${KUBERNETES_VERSION:=1.28.5}+k3s1"
+  version: "v${KUBERNETES_VERSION:=1.30.2}+k3s1"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElementalCluster

--- a/infrastructure-elemental/v0.0.0/cluster-template-k3s.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-k3s.yaml
@@ -1,4 +1,4 @@
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KThreesConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
@@ -23,7 +23,7 @@ spec:
       cidrBlocks: ${POD_CIDR:=["10.244.0.0/16"]}
     serviceDomain: ${SERVICE_DOMAIN:="cluster.local"}
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: KThreesControlPlane
     name: ${CLUSTER_NAME}-control-plane
   infrastructureRef:
@@ -48,7 +48,7 @@ spec:
     spec:
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
           kind: KThreesConfigTemplate
           name: ${CLUSTER_NAME}-md-0
       clusterName: ${CLUSTER_NAME}
@@ -56,20 +56,21 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: ElementalMachineTemplate
         name: ${CLUSTER_NAME}-md-0
-      version: "v${KUBERNETES_VERSION:=1.28.5}+k3s1"
+      version: "v${KUBERNETES_VERSION:=1.30.2}+k3s1"
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KThreesControlPlane
 metadata:
   name: ${CLUSTER_NAME}-control-plane
   namespace: ${NAMESPACE}
 spec:
-  infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: ElementalMachineTemplate
-    name: ${CLUSTER_NAME}-control-plane
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: ElementalMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
   replicas: ${CONTROL_PLANE_MACHINE_COUNT:=1}
-  version: "v${KUBERNETES_VERSION:=1.28.5}+k3s1"
+  version: "v${KUBERNETES_VERSION:=1.30.2}+k3s1"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ElementalCluster

--- a/test/scripts/apply_all_templates.sh
+++ b/test/scripts/apply_all_templates.sh
@@ -68,21 +68,20 @@ k3s > $MANIFEST_K3S
 kubectl create namespace $MANIFEST_K3S_NAMESPACE
 kubectl apply -f $MANIFEST_K3S
 
-## k3s clusterclass not supported upstream yet
-# printf "\n##### k3s-clusterclass #####\n"
-# MANIFEST_K3S_CLUSTERCLASS="$MANIFESTS_DIR/k3s-clusterclass.yaml"
-# MANIFEST_K3S_CLUSTERCLASS_NAMESPACE="k3s-clusterclass"
-# kubectl delete namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE --ignore-not-found
-# clusterctl generate cluster --config $CONFIG_FILE \
-# --control-plane-machine-count=1 \
-# --worker-machine-count=1 \
-# --infrastructure elemental:$PROVIDER_VERSION \
-# --target-namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE \
-# --flavor k3s-clusterclass \
-# --v $LOG_LEVEL \
-# k3s-clusterclass > $MANIFEST_K3S_CLUSTERCLASS
-# kubectl create namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE
-# kubectl apply -f $MANIFEST_K3S_CLUSTERCLASS
+printf "\n##### k3s-clusterclass #####\n"
+MANIFEST_K3S_CLUSTERCLASS="$MANIFESTS_DIR/k3s-clusterclass.yaml"
+MANIFEST_K3S_CLUSTERCLASS_NAMESPACE="k3s-clusterclass"
+kubectl delete namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE --ignore-not-found
+clusterctl generate cluster --config $CONFIG_FILE \
+--control-plane-machine-count=1 \
+--worker-machine-count=1 \
+--infrastructure elemental:$PROVIDER_VERSION \
+--target-namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE \
+--flavor k3s-clusterclass \
+--v $LOG_LEVEL \
+k3s-clusterclass > $MANIFEST_K3S_CLUSTERCLASS
+kubectl create namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE
+kubectl apply -f $MANIFEST_K3S_CLUSTERCLASS
 
 # rke2
 printf "\n##### rke2 #####\n"


### PR DESCRIPTION
Updated the k3s manifests to use the newer `v1beta2` version. 
ClusterClass for k3s is also supported now, and I bumped the version to latest k3s release why not.