### PR TITLE
Fix rke2 cluster class

### DIFF
--- a/infrastructure-elemental/v0.0.0/cluster-template-rke2-clusterclass.yaml
+++ b/infrastructure-elemental/v0.0.0/cluster-template-rke2-clusterclass.yaml
@@ -31,4 +31,6 @@ spec:
       value: ${CONTROL_PLANE_ENDPOINT_PORT:=6443}
     - name: vipInterface
       value: ${VIP_INTERFACE:=eth0}
+    - name: k8sVersion
+      value: "v${KUBERNETES_VERSION:=1.30.1}+rke2r1"
 

--- a/infrastructure-elemental/v0.0.0/clusterclass-rke2.yaml
+++ b/infrastructure-elemental/v0.0.0/clusterclass-rke2.yaml
@@ -50,6 +50,11 @@ spec:
         openAPIV3Schema:
           type: string
           default: "eth0"
+    - name: k8sVersion
+      required: true
+      schema:
+        openAPIV3Schema:
+          type: string
   patches:
     - name: elementalClusterTemplate
       definitions:
@@ -76,7 +81,11 @@ spec:
               controlPlane: true
           jsonPatches:
             - op: add
-              path: "/spec/template/spec/kubeadmConfigSpec/files"
+              path: "/spec/template/spec/version"
+              valueFrom:
+                variable: k8sVersion
+            - op: add
+              path: "/spec/template/spec/files"
               valueFrom:
                 template: |
                   - content: |

--- a/test/scripts/apply_all_templates.sh
+++ b/test/scripts/apply_all_templates.sh
@@ -68,21 +68,20 @@ k3s > $MANIFEST_K3S
 kubectl create namespace $MANIFEST_K3S_NAMESPACE
 kubectl apply -f $MANIFEST_K3S
 
-## k3s clusterclass not supported upstream yet
-# printf "\n##### k3s-clusterclass #####\n"
-# MANIFEST_K3S_CLUSTERCLASS="$MANIFESTS_DIR/k3s-clusterclass.yaml"
-# MANIFEST_K3S_CLUSTERCLASS_NAMESPACE="k3s-clusterclass"
-# kubectl delete namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE --ignore-not-found
-# clusterctl generate cluster --config $CONFIG_FILE \
-# --control-plane-machine-count=1 \
-# --worker-machine-count=1 \
-# --infrastructure elemental:$PROVIDER_VERSION \
-# --target-namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE \
-# --flavor k3s-clusterclass \
-# --v $LOG_LEVEL \
-# k3s-clusterclass > $MANIFEST_K3S_CLUSTERCLASS
-# kubectl create namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE
-# kubectl apply -f $MANIFEST_K3S_CLUSTERCLASS
+printf "\n##### k3s-clusterclass #####\n"
+MANIFEST_K3S_CLUSTERCLASS="$MANIFESTS_DIR/k3s-clusterclass.yaml"
+MANIFEST_K3S_CLUSTERCLASS_NAMESPACE="k3s-clusterclass"
+kubectl delete namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE --ignore-not-found
+clusterctl generate cluster --config $CONFIG_FILE \
+--control-plane-machine-count=1 \
+--worker-machine-count=1 \
+--infrastructure elemental:$PROVIDER_VERSION \
+--target-namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE \
+--flavor k3s-clusterclass \
+--v $LOG_LEVEL \
+k3s-clusterclass > $MANIFEST_K3S_CLUSTERCLASS
+kubectl create namespace $MANIFEST_K3S_CLUSTERCLASS_NAMESPACE
+kubectl apply -f $MANIFEST_K3S_CLUSTERCLASS
 
 # rke2
 printf "\n##### rke2 #####\n"
@@ -100,21 +99,20 @@ rke2 > $MANIFEST_RKE2
 kubectl create namespace $MANIFEST_RKE2_NAMESPACE
 kubectl apply -f $MANIFEST_RKE2
 
-# rke2 clusterclass not supported upstream yet
-# printf "\n##### rke2-clusterclass #####\n"
-# MANIFEST_RKE2_CLUSTERCLASS="$MANIFESTS_DIR/rke2-clusterclass.yaml"
-# MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE="rke2-clusterclass"
-# kubectl delete namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE --ignore-not-found
-# clusterctl generate cluster --config $CONFIG_FILE \
-# --control-plane-machine-count=1 \
-# --worker-machine-count=1 \
-# --infrastructure elemental:$PROVIDER_VERSION \
-# --target-namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE \
-# --flavor rke2-clusterclass \
-# --v $LOG_LEVEL \
-# rke2-clusterclass > $MANIFEST_RKE2_CLUSTERCLASS
-# kubectl create namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE
-# kubectl apply -f $MANIFEST_RKE2_CLUSTERCLASS
+printf "\n##### rke2-clusterclass #####\n"
+MANIFEST_RKE2_CLUSTERCLASS="$MANIFESTS_DIR/rke2-clusterclass.yaml"
+MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE="rke2-clusterclass"
+kubectl delete namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE --ignore-not-found
+clusterctl generate cluster --config $CONFIG_FILE \
+--control-plane-machine-count=1 \
+--worker-machine-count=1 \
+--infrastructure elemental:$PROVIDER_VERSION \
+--target-namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE \
+--flavor rke2-clusterclass \
+--v $LOG_LEVEL \
+rke2-clusterclass > $MANIFEST_RKE2_CLUSTERCLASS
+kubectl create namespace $MANIFEST_RKE2_CLUSTERCLASS_NAMESPACE
+kubectl apply -f $MANIFEST_RKE2_CLUSTERCLASS
 
 # kubeadm
 printf "\n##### kubeadm #####\n"


### PR DESCRIPTION
This PR fixes the RKE2 Cluster Class by patching the k8s version which is now defined as a variable.

I also took the occasion to enable all remaining templates in the test-all script. This script is currently not used in an automated fashion, but it could just to validate our manifests can be applied.

This is also related to https://github.com/rancher/cluster-api-provider-rke2/issues/354
The issue was fixed for me in the `0.5.0` release of the RKE2 provider (but I think it was actually fixed by `0.4.0` before that)