### PR TITLE
Expose ELEMENTAL_AGENT and ELEMENTAL_TOOLKIT OS build args

### DIFF
--- a/Dockerfile.os
+++ b/Dockerfile.os
@@ -1,5 +1,5 @@
-ARG ELEMENTAL_TOOLKIT=ghcr.io/rancher/elemental-toolkit/elemental-cli:nightly
-ARG ELEMENTAL_AGENT=ghcr.io/rancher-sandbox/cluster-api-provider-elemental/agent:latest
+ARG ELEMENTAL_TOOLKIT
+ARG ELEMENTAL_AGENT
 
 FROM ${ELEMENTAL_AGENT} as AGENT
 FROM  ${ELEMENTAL_TOOLKIT} as TOOLKIT

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,8 @@ endif
 		--build-arg "COMMITDATE=${GIT_COMMIT_DATE}" \
 		--build-arg "AGENT_CONFIG_FILE=${AGENT_CONFIG_FILE}" \
 		--build-arg "KUBEADM_READY=${KUBEADM_READY_OS}" \
+		--build-arg "ELEMENTAL_TOOLKIT=${ELEMENTAL_TOOLKIT_IMAGE}" \
+		--build-arg "ELEMENTAL_AGENT=${ELEMENTAL_AGENT_IMAGE}" \
 		-t elemental-os:dev -f Dockerfile.os .
 
 .PHONY: build-iso


### PR DESCRIPTION
Forgot this from #81 
I removed the defaults from the Dockerfile so we only have to maintain them in the Makefile.